### PR TITLE
Improve deploy and undeploy tasks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 .classpath
 .project
 .settings/gradle
+

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ The plugin will have made the following tasks available to your project:
 | libertyDebug | Runs the Liberty Profile server in the console foreground after a debugger connects to the debug port (default: 7777). | 
 | libertyStatus | Checks the WebSphere Liberty Profile server is running. |
 | libertyPackage | Generates a WebSphere Liberty Profile server archive. |
-| deployWar | Deploys a WAR file to the WebSphere Liberty Profile server. |
-| undeployWar | Removes a WAR file from the WebSphere Liberty Profile server. |
+| deploy | Deploys a supported file to the WebSphere Liberty Profile server. |
+| undeploy | Removes an application from the WebSphere Liberty Profile server. |
 | installFeature | Installs a new feature in the WebSphere Liberty Profile server. |
 
 ###Extension properties
@@ -118,6 +118,7 @@ These properties are divided in two groups, the general properties (Which need t
 | userDir | Value of the `${wlp_user_dir}` variable. The default value is `${installDir}/usr/`. | No |
 | serverName |Name of the Liberty profile server instance. The default value is `defaultServer`. | No |
 
+
 #### Server Properties
 
 | Attribute | Description | Required |
@@ -129,6 +130,9 @@ These properties are divided in two groups, the general properties (Which need t
 | template | Name of the template to use when creating a new server. Only used with the `libertyCreate` task. | No |
 
 This example shows you how to configure these properties in your script:
+=======
+This example shows you how to configure this properties in your script:
+
 ```groovy
 apply plugin: 'liberty'
 
@@ -159,6 +163,7 @@ liberty {
 Of the plugin configuration, only the `wlpDir` property is required. The default configuration is to use a server named `defaultServer` under the `build\wlp` directory of the Gradle project.
 
 
+
 ### installLiberty task
 
 The `installLiberty` task is used to download and install Liberty profile server. The task can download the Liberty runtime archive from a specified location (via `runtimeUrl`) or automatically resolve it from the [Liberty repository](https://developer.ibm.com/wasdev/downloads/) based on a version. 
@@ -181,6 +186,7 @@ The Liberty license code must always be set in order to install the runtime. If 
 #### Examples
 
 ```groovy
+
     // Install using Liberty repository
     apply plugin: 'liberty'
 
@@ -206,7 +212,104 @@ The Liberty license code must always be set in order to install the runtime. If 
 
 ```
 
-####**installFeature** task properties.
+### deploy task
+
+The `deploy` task supports deployment of one or more applications to the Liberty Profile server.
+
+####**Properties**.
+
+| Attribute | Description | Required |
+| --------- | ------------ | ----------|
+| file| Location of a single application to be deployed. The application type can be war, ear, rar, eba, zip, or jar. | Yes, only when a single file will be deployed. |
+| dir|  Location of the directory where are the applications to be deployed.| Yes, only when multiples files will be deployed and `file` is not specified.|
+| include| Comma- or space-separated list of patterns of files that must be included. All files are included when omitted.| No |
+| exclude| Comma- or space-separated list of patterns of files that must be excluded. No files are excluded when omitted.| No |
+
+
+Deploy's properties must be set up in the `deploy` closure inside the `liberty` closure.
+
+```
+    // Deploys a single file
+    apply plugin: 'liberty'
+
+    liberty {
+        wlpDir = 'c:/wlp'
+        serverName = 'myServer'
+        
+        deploy {
+            file = 'c:/files/app.war'
+        }
+    }
+
+    //Deploy multiples files
+    /*Deploy 'app.war' and 'sample.war' 
+      but exclude 'test-war.war'*/
+    apply plugin: 'liberty'
+
+    liberty {
+        
+        wlpDir = 'c:/wlp'
+        serverName = 'myServer'
+        
+        deploy {
+            dir = 'c:/files'
+            include = 'app.war, sample.war'
+            exclude = 'test-war.war'
+        }
+    }
+```
+
+### undeploy task
+
+The `undeploy` task supports undeployment of one or more applications from the Liberty Profile server.
+
+####**Properties**.
+
+| Attribute | Description | Required |
+| --------- | ------------ | ----------|
+| application| Name of the application to be undeployed.| Yes, only when a single application will be undeployed. |
+| include| Comma- or space-separated list of patterns of files that must be included. All files are included when omitted.| No |
+| exclude| Comma- or space-separated list of patterns of files that must be excluded. No files are excluded when omitted.| No |
+
+Undeploy's properties must be set up in the `undeploy` closure inside the `liberty` closure.
+
+#### Examples
+
+```groovy
+    // Undeploys a single application
+    
+    apply plugin: 'liberty'
+
+    liberty {
+        wlpDir = 'c:/wlp'
+        serverName = 'myServer'
+        
+        undeploy {
+            application = 'app.war'
+        }
+    }
+
+    //Undeploy multiples applications
+    /*Undeploy 'app.war' and 'sample.war' 
+      but exclude 'test-war.war'*/
+      
+    apply plugin: 'liberty'
+
+    liberty {
+        
+        wlpDir = 'c:/wlp'
+        serverName = 'myServer'
+        
+        undeploy {
+            include = 'app.war, sample.war'
+            exclude = 'test-war.war'
+        }
+    }
+```
+### installFeature task
+The `installFeature` task installs a feature packaged as a Subsystem Archive (ESA file) to the Liberty runtime.
+
+####**Properties**.
 
 | Attribute | Description | Required |
 | --------- | ------------ | ----------|
@@ -217,7 +320,8 @@ The Liberty license code must always be set in order to install the runtime. If 
 
 The following example shows what properties must be set up to install the [`mongodb-2.0`](https://developer.ibm.com/wasdev/downloads/#asset/features-com.ibm.websphere.appserver.mongodb-2.0) feature to your server:
 
-```
+
+```groovy
 apply plugin: 'liberty'
 
 liberty {

--- a/README.md
+++ b/README.md
@@ -130,8 +130,6 @@ These properties are divided in two groups, the general properties (Which need t
 | template | Name of the template to use when creating a new server. Only used with the `libertyCreate` task. | No |
 
 This example shows you how to configure these properties in your script:
-=======
-This example shows you how to configure this properties in your script:
 
 ```groovy
 apply plugin: 'liberty'
@@ -257,7 +255,56 @@ Deploy's properties must be set up in the `deploy` closure inside the `liberty` 
             exclude = 'test-war.war'
         }
     }
+    
+    /*Deploy multiple files using multiple closures*/
+    
+    apply plugin: 'liberty'
+
+    liberty {
+        
+        wlpDir = 'c:/wlp'
+        serverName = 'myServer'
+        
+        deploy {
+            file = 'c:/files/app.war'
+        }
+
+        deploy {
+            file = 'c:/resources/test.war'
+        }
+        
+        deploy {
+            dir = 'c:/extras'
+            include = 'sample.war, demo.war'
+        }
+    }
 ```
+
+The following examples shows you how to deploy a file using the `WAR` or the `EAR` gradle plugins:
+
+```
+    /* Deploys 'sample.war' using the WAR plugin */
+    apply plugin: 'war'
+
+    war {
+        destinationDir = new File ('C:/files')
+        archiveName = 'sample.war'
+    }
+```
+
+`destinationDir` and `archiveName` are native properties of the Gradle's WAR plugin. For more information see [here.](https://gradle.org/docs/current/dsl/org.gradle.api.tasks.bundling.War.html)
+
+```
+    /* Deploys 'test.ear' using the EAR plugin */
+    apply plugin: 'ear'
+
+    ear {
+        destinationDir = new File ('C:/files')
+        archiveName = 'test.ear'
+    }
+```
+
+`destinationDir` and `archiveName` are native properties of the Gradle's EAR plugin. For more information see [here.](https://gradle.org/docs/current/dsl/org.gradle.plugins.ear.Ear.html)
 
 ### undeploy task
 
@@ -306,6 +353,9 @@ Undeploy's properties must be set up in the `undeploy` closure inside the `liber
         }
     }
 ```
+
+If none property is set,  all the applications availables in the server at the moment of the execution will be undeployed.
+
 ### installFeature task
 The `installFeature` task installs a feature packaged as a Subsystem Archive (ESA file) to the Liberty runtime.
 
@@ -329,6 +379,21 @@ liberty {
 
     features {
         name = ['mongodb-2.0']
+        acceptLicense = true
+    } 
+}
+```
+
+Also is possible install multiple features in a single closure, for example:
+```groovy
+/* Install 'mongodb-2.0' and 'ejbLite-3.1' features using a single closure. */
+apply plugin: 'liberty'
+
+liberty {
+    wlpDir = "c:/wlp"
+
+    features {
+        name = ['mongodb-2.0', 'ejbLite-3.1']
         acceptLicense = true
     } 
 }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
@@ -38,8 +38,6 @@ class Liberty implements Plugin<Project> {
 
     void apply(Project project) {
 
-        project.plugins.apply 'war'
-
         project.extensions.create('liberty', LibertyExtension)
 
         project.task('installLiberty', type: InstallLibertyTask) {
@@ -82,7 +80,6 @@ class Liberty implements Plugin<Project> {
             description 'Stops the WebSphere Liberty Profile server.'
             logging.level = LogLevel.INFO
         }
-        project.tasks.clean.dependsOn project.tasks.libertyStop
 
         project.task('libertyPackage', type: PackageTask) {
             description 'Generates a WebSphere Liberty Profile server archive.'
@@ -104,16 +101,16 @@ class Liberty implements Plugin<Project> {
             logging.level = LogLevel.INFO
         }
 
-        project.task('deployWar', type: DeployTask) {
-            description 'Deploys a WAR file to the WebSphere Liberty Profile server.'
+        project.task('deploy', type: DeployTask) {
+            description 'Deploys a supported file to the WebSphere Liberty Profile server.'
             logging.level = LogLevel.INFO
         }
 
-        project.task('undeployWar', type: UndeployTask) {
-            description 'Removes a WAR file from the WebSphere Liberty Profile server.'
+        project.task('undeploy', type: UndeployTask) {
+            description 'Removes an application from the WebSphere Liberty Profile server.'
             logging.level = LogLevel.INFO
         }
-        
+
         project.task('installFeature', type: InstallFeatureTask) {
             description 'Install a new feature to the WebSphere Liberty Profile server'
             logging.level = LogLevel.INFO

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
@@ -37,7 +37,7 @@ import org.gradle.api.logging.LogLevel
 class Liberty implements Plugin<Project> {
 
     void apply(Project project) {
-
+        
         project.extensions.create('liberty', LibertyExtension)
 
         project.task('installLiberty', type: InstallLibertyTask) {

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/DeployExtension.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/DeployExtension.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2015.
+ * (C) Copyright IBM Corporation 2015.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package net.wasdev.wlp.gradle.plugins.extensions
 
-class FeatureExtension {
-
-    String[] name
-    boolean acceptLicense = false
-    String whenFileExists
-    String to
+class DeployExtension {
+  
+    String dir
+    String include
+    String exclude
+    String file
 
 }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/DeployExtension.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/DeployExtension.groovy
@@ -15,11 +15,18 @@
  */
 package net.wasdev.wlp.gradle.plugins.extensions
 
-class DeployExtension {
+class DeployExtension implements Cloneable{
   
     String dir
-    String include
+    String include = ""
     String exclude
     String file
+    List<Object> listOfClosures = new ArrayList<Object>()
 
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        super.clone()
+    }
 }
+
+

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/LibertyExtension.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/LibertyExtension.groovy
@@ -29,6 +29,10 @@ class LibertyExtension {
     
     FeatureExtension features = new FeatureExtension()
     InstallExtension install = new InstallExtension()
+
+    DeployExtension deploy = new DeployExtension()
+    UndeployExtension undeploy = new UndeployExtension()
+    
     PackageAndDumpExtension packageLiberty = new PackageAndDumpExtension()
     PackageAndDumpExtension dumpLiberty = new PackageAndDumpExtension()
     PackageAndDumpExtension javaDumpLiberty = new PackageAndDumpExtension()
@@ -41,6 +45,14 @@ class LibertyExtension {
         ConfigureUtil.configure(closure, install)
     }
 
+    def deploy(Closure closure) {
+        ConfigureUtil.configure(closure, deploy)
+    }
+
+    def undeploy(Closure closure) {
+        ConfigureUtil.configure(closure, undeploy)
+    }
+    
     def packageLiberty(Closure closure) {
         ConfigureUtil.configure(closure, packageLiberty)
     }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/LibertyExtension.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/LibertyExtension.groovy
@@ -23,16 +23,19 @@ class LibertyExtension {
     String outputDir
     String userDir
     String serverName = "defaultServer"
+
     boolean clean = false
     String timeout
     String template
-    
+
+    def numberOfClosures = 0    
+
     FeatureExtension features = new FeatureExtension()
     InstallExtension install = new InstallExtension()
 
     DeployExtension deploy = new DeployExtension()
     UndeployExtension undeploy = new UndeployExtension()
-    
+
     PackageAndDumpExtension packageLiberty = new PackageAndDumpExtension()
     PackageAndDumpExtension dumpLiberty = new PackageAndDumpExtension()
     PackageAndDumpExtension javaDumpLiberty = new PackageAndDumpExtension()
@@ -46,7 +49,12 @@ class LibertyExtension {
     }
 
     def deploy(Closure closure) {
+        if (numberOfClosures > 0){
+            deploy.listOfClosures.add(deploy.clone())
+            deploy.file = null
+        }
         ConfigureUtil.configure(closure, deploy)
+        numberOfClosures++
     }
 
     def undeploy(Closure closure) {

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/UndeployExtension.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/UndeployExtension.groovy
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014, 2015.
+ * (C) Copyright IBM Corporation 2015.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  */
 package net.wasdev.wlp.gradle.plugins.extensions
 
-class FeatureExtension {
+class UndeployExtension {
 
-    String[] name
-    boolean acceptLicense = false
-    String whenFileExists
-    String to
+    String application
+    String include
+    String exclude
 
 }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/UndeployExtension.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/extensions/UndeployExtension.groovy
@@ -18,7 +18,7 @@ package net.wasdev.wlp.gradle.plugins.extensions
 class UndeployExtension {
 
     String application
-    String include
+    String include = ""
     String exclude
 
 }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/AbstractTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/AbstractTask.groovy
@@ -15,6 +15,8 @@
  */
 package net.wasdev.wlp.gradle.plugins.tasks
 
+import net.wasdev.wlp.gradle.plugins.extensions.DeployExtension
+import net.wasdev.wlp.gradle.plugins.extensions.LibertyExtension
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/DeployTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/DeployTask.groovy
@@ -22,12 +22,31 @@ class DeployTask extends AbstractTask {
     @TaskAction
     void deploy() {
         def params = buildLibertyMap(project);
+
         params.put('timeout', project.liberty.timeout)
         params.put('file', project.war.archivePath)
+
         project.ant.taskdef(name: 'deploy', 
                             classname: 'net.wasdev.wlp.ant.DeployTask', 
                             classpath: project.buildscript.configurations.classpath.asPath)
-        project.ant.deploy(params)
+
+        def deployDir = project.liberty.deploy.dir
+        def fileToDeploy = project.liberty.deploy.file
+        def include = project.liberty.deploy.include
+        def exclude = project.liberty.deploy.exclude
+        
+        if (fileToDeploy != null) {
+            params.put('file', fileToDeploy)
+            project.ant.deploy(params)
+        } else {
+            if (deployDir != null) {
+                project.ant.deploy(params) {
+                    fileset(dir:deployDir, includes: include, excludes: exclude)
+                }
+            } else {
+                project.ant.deploy(params)
+            }
+        }
     }
 
 }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/UndeployTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/UndeployTask.groovy
@@ -22,12 +22,29 @@ class UndeployTask extends AbstractTask {
     @TaskAction
     void undeploy() {
         def params = buildLibertyMap(project);
+
         params.put('timeout', project.liberty.timeout)
         params.put('file', project.war.archiveName)
+
         project.ant.taskdef(name: 'undeploy', 
                             classname: 'net.wasdev.wlp.ant.UndeployTask', 
                             classpath: project.buildscript.configurations.classpath.asPath)
-        project.ant.undeploy(params)
+
+        def application = project.liberty.undeploy.application
+        def include = project.liberty.undeploy.include
+        def exclude = project.liberty.undeploy.exclude
+
+        if (application != null) {
+            params.put('file', application)
+            project.ant.undeploy(params)
+        } else if (include != null || exclude != null) {
+            project.ant.undeploy(params) {
+                patternset(includes: include, excludes: exclude)
+            }
+        }
+        else {
+            project.ant.undeploy(params)
+        }
     }
 
 }


### PR DESCRIPTION
This refactor let us to use a closure to deploy/undeploy one or multiple files. 

For example, for multiples files: 
````
liberty {
    deploy {
        dir = "C:/resources"
        include = " *.war, *.ear "
        exclude = " *.txt "    
    }
}
````
Include and Exclude could be set with wildcards.

If you wan to deploy a single file you should use the following code instead:

````
liberty {
    deploy {
        file = "C:/resources/test-war.war"
    }
}
````