### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ gradlew build -PwlpInstallDir=<liberty_install_directory>
 
 ## Usage
 ###1. Configuring your dependencies
-#### 1.1 Adding the ant plugin to the build script
+####  Adding the ant plugin to the build script
 This plugin needs the `wlp-anttasks.jar`file as dependency, this file can be downloaded from the [snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/net/wasdev/wlp/ant/wlp-anttasks/) or the [Maven central repository](http://repo1.maven.org/maven2/net/wasdev/wlp/ant/wlp-anttasks/).
 
 The following code snippet shows an example on how to set up your build script correctly.
@@ -33,18 +33,6 @@ The following code snippet shows an example on how to set up your build script c
 buildscript {
     dependencies {
         classpath files('gradle/wlp-anttasks.jar')
-    }
-}
-```
-
-####1.2 Configuring the path to your WebSphere Application Server Liberty Profile installation
-You need to set up the classpath to the `ws-server.jar` of your WebSphere Application Server Liberty Profile installation. This JAR is located inside `/bin/tools/` in your installation folder.
-
-For example:
-```groovy
-buildscript {
-    dependencies {
-        classpath files('c:/wlp/bin/tools/ws-server.jar')
     }
 }
 ```
@@ -80,7 +68,6 @@ buildscript {
     dependencies {
         classpath files('gradle/liberty-gradle-plugin.jar')
         classpath files('gradle/wlp-anttasks.jar')
-        classpath files('c:/wlp/bin/tools/ws-server.jar')
     }
 }
 ```


### PR DESCRIPTION
You don´t need to include a ws-server.jar as a dependency to use the
plugin.