### PR TITLE
libertyStatus uses ProcessBuilder to print to console

### DIFF
--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/StatusTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/StatusTask.groovy
@@ -21,7 +21,10 @@ class StatusTask extends AbstractTask {
 
     @TaskAction
     void status() {
-        executeServerCommand(project, 'status', buildLibertyMap(project))
+        def status_process = new ProcessBuilder(buildCommand("status")).redirectErrorStream(true).start()
+        status_process.inputStream.eachLine {
+            println it
+        }
     }
 
 }


### PR DESCRIPTION
pretty simple and self explanatory change. the original executeServerCommand did not print to console by default