### PR TITLE
Only copy the currently used test*.gradle file

### DIFF
--- a/docs/addingTests.md
+++ b/docs/addingTests.md
@@ -32,10 +32,9 @@ public class YourAwesomeTest extends AbstractIntegrationTest{
             // copy your testing resources into your build directory 
             createTestProject(buildDir, sourceDir, buildFilename) // **required**
         }
-        // copy your testing resource into your build directory 
+        // copy your testing resource into your build directory as
+        // well as your needed .gradle files.
         createTestProject(buildDir, resourceDir, buildFilename) // **required**
-        // rename your build file to build.gradle so you can build with it...
-        renameBuildFile(buildFilename, buildDir) // **required**
     }
 
     // Any configuration you need to run after your test suite

--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/AbstractIntegrationTest.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/AbstractIntegrationTest.groovy
@@ -21,8 +21,6 @@ import org.apache.commons.io.FileUtils
 import org.gradle.tooling.BuildLauncher
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
-import java.nio.file.StandardCopyOption
-import java.nio.file.Files
 import java.io.File
 
 


### PR DESCRIPTION
On windows tests were failing because the framework could not rename the test*.gradle file to build.gradle because of an existing build.gradle file.  It was also confusing to see all the gradle files in the test output when only one was being used.