### PR TITLE
Dependencies are now accessed through Tasks instead of by Project

### DIFF
--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/TestLooseApplication.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/TestLooseApplication.groovy
@@ -21,7 +21,7 @@ import org.w3c.dom.NodeList;
 public class TestLooseApplication extends AbstractIntegrationTest{
     static File resourceDir = new File("build/resources/integrationTest/sample.servlet")
     static File buildDir = new File(integTestDir, "/test-loose-application")
-    static String buildFilename = "TestLooseApplication.gradle"
+    static String buildFilename = "testLooseApplication.gradle"
 
     @BeforeClass
     public static void setup() {

--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/TestLooseApplicationWithWarTask.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/TestLooseApplicationWithWarTask.groovy
@@ -21,7 +21,7 @@ import org.w3c.dom.NodeList;
 public class TestLooseApplicationWithWarTask extends AbstractIntegrationTest{
     static File resourceDir = new File("build/resources/integrationTest/sample.servlet")
     static File buildDir = new File(integTestDir, "/test-loose-application-with-war-tasks")
-    static String buildFilename = "TestLooseApplicationWithWarTask.gradle"
+    static String buildFilename = "testLooseApplicationWithWarTask.gradle"
 
     @BeforeClass
     public static void setup() {

--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/TestWarTasksWithDifferentDependencies.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/TestWarTasksWithDifferentDependencies.groovy
@@ -1,0 +1,39 @@
+package net.wasdev.wlp.gradle.plugins;
+
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+
+public class TestWarTasksWithDifferentDependencies extends AbstractIntegrationTest{
+    static File resourceDir = new File("build/resources/integrationTest/sample.servlet-noWebAppConfig")
+    static File buildDir = new File(integTestDir, "/test-war-tasks-with-different-dependencies")
+    static String buildFilename = "testWarTasksWithDifferentDependencies.gradle"
+
+    @BeforeClass
+    public static void setup() {
+        createDir(buildDir)
+        if(test_mode == "offline"){
+            WLP_DIR.replace("\\","/")
+        }
+        createTestProject(buildDir, resourceDir, buildFilename)
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        runTasks(buildDir, 'libertyStop')
+    }
+
+    @Test
+    public void test_start_with_timeout_success() {
+        try {
+            runTasks(buildDir, 'libertyStart')
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task libertyStart. "+ e)
+        }
+        assert new File('build/testBuilds/test-war-tasks-with-different-dependencies/build/wlp/usr/servers/LibertyProjectServer/dropins/sample.servlet-1.war').exists() : 'application not installed on server'
+        assert new File('build/testBuilds/test-war-tasks-with-different-dependencies/build/wlp/usr/servers/LibertyProjectServer/dropins/sample.servlet4-1.war').exists() : 'application not installed on server'
+
+        assert new File('build/testBuilds/test-war-tasks-with-different-dependencies/build/wlp/usr/servers/LibertyProjectServer/apps/sample.servlet2-1.war').exists() : 'application not installed on server'
+        assert new File('build/testBuilds/test-war-tasks-with-different-dependencies/build/wlp/usr/servers/LibertyProjectServer/apps/sample.servlet3-1.war').exists() : 'application not installed on server'
+    }
+}

--- a/src/integTest/resources/sample.servlet-noWebAppConfig/testWarTasksWithDifferentDependencies.gradle
+++ b/src/integTest/resources/sample.servlet-noWebAppConfig/testWarTasksWithDifferentDependencies.gradle
@@ -1,7 +1,3 @@
-/*
-	This test checks whether the application was successfully installed without the version number in the package
-	when installApps is called and stripVersion is set to true.
-*/
 group = 'liberty.gradle'
 version = '1'
 
@@ -19,7 +15,6 @@ buildscript {
     }
 }
 
-apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'war'
 apply plugin: 'liberty'
@@ -43,29 +38,39 @@ ext {
     packagingType = 'usr'
 
 }
+configurations {
+  war2.extendsFrom runtime
+  war4.extendsFrom runtime
+}
 
 repositories {
     mavenCentral()
 }
 
-configurations {
-  war2.extendsFrom runtime
-}
-
 dependencies {
     testCompile 'junit:junit:4.12'
+    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testCompile 'org.glassfish:javax.json:1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
-    compile 'org.apache.commons:commons-text:1.1'
     war2 'org.apache.commons:commons-proxy:1.0'
-}
-
-task war1(type:War){
-    baseName = 'sample.servlet1'
+    war4 'org.apache.commons:commons-text:1.1'
 }
 
 task war2(type:War){
     baseName = 'sample.servlet2'
     classpath = configurations.war2
+    println 'war2 archiveName = ' + archiveName
+}
+
+task war3(type:War){
+    baseName = 'sample.servlet3'
+    println 'war3 archiveName = ' + archiveName
+}
+
+task war4(type:War){
+    baseName = 'sample.servlet4'
+    classpath = configurations.war4
+    println 'war4 archiveName = ' + archiveName
 }
 
 liberty {
@@ -79,11 +84,11 @@ liberty {
             archive = packageFile
             include = packagingType
         }
-      installapps{
-          looseApplication = true
-          stripVersion = true
-      }
-    	apps = [war1, war2]
+        installapps{
+            looseApplication = false
+        }
+    	apps = [war2, war3]
+      dropins = [war, war4]
       verifyAppStartTimeout = 30
     }
 }
@@ -114,5 +119,9 @@ task printMessageAboutRunningServer {
     }
 }
 
+check.dependsOn 'integrationTest'
 installApps.dependsOn tasks.withType(War)
+libertyStart.dependsOn 'installApps'
+integrationTest.dependsOn 'libertyStart', 'testClasses'
+integrationTest.finalizedBy 'libertyStop'
 libertyStart.finalizedBy 'printMessageAboutRunningServer'

--- a/src/integTest/resources/sample.servlet/testLooseApplication.gradle
+++ b/src/integTest/resources/sample.servlet/testLooseApplication.gradle
@@ -50,7 +50,6 @@ liberty {
 
     installapps{
         stripVersion = true
-        looseApplication = true
     }
 }
 
@@ -70,7 +69,6 @@ test {
     reports.junitXml.destination = file("$buildDir/test-results/unit")
     exclude '**/it/**'
 }
-
 
 task integrationTest(type: Test) {
     group 'Verification'

--- a/src/integTest/resources/sample.servlet/testLooseApplicationWithWarTask.gradle
+++ b/src/integTest/resources/sample.servlet/testLooseApplicationWithWarTask.gradle
@@ -80,7 +80,6 @@ liberty {
             include = packagingType
         }
       installapps{
-          looseApplication = true
           stripVersion = true
       }
     	apps = [war1, war2]

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallAppsTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallAppsTask.groovy
@@ -200,8 +200,11 @@ class InstallAppsTask extends AbstractServerTask {
 
     private void addWarEmbeddedLib(Element parent, LooseApplication looseApp, Task task) throws Exception {
       ArrayList<File> deps = new ArrayList<File>();
-      project.configurations.runtime.each { deps.add(it)}
-      project.configurations.providedRuntime.each { deps.remove(it) }
+      task.classpath.each {deps.add(it)}
+      //Removes WEB-INF/lib/main directory since it is not rquired in the xml
+      if(deps != null && !deps.isEmpty()){
+        deps.remove(0)
+      }
       File parentProjectDir = new File(task.getProject().getRootProject().rootDir.getAbsolutePath())
       for (File dep: deps) {
         String projectPath = getProjectPath(parentProjectDir, dep)


### PR DESCRIPTION
-Added tests where tasks have different dependencies, for both looseConfig true|false.
-Changed installApps to get dependencies from the task instead of the project