### PR TITLE
Fixed unexpected warnings in libertyPackage

### DIFF
--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/PackageTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/PackageTask.groovy
@@ -27,7 +27,6 @@ class PackageTask extends AbstractServerTask {
 
         def archive = server.packageLiberty.archive
 
-        copyConfigFiles()
         if (archive != null && archive.length() != 0) {
             def archiveFile = new File(archive)
 


### PR DESCRIPTION
Removed unnecessary copy method from libertyPackage task
fixes #142