### PR TITLE
updating plugin-config file and adding eclipse task dependency

### DIFF
--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
@@ -51,6 +51,7 @@ class Liberty implements Plugin<Project> {
 
         //Used to set project facets in Eclipse
         project.pluginManager.apply('eclipse-wtp')
+        project.tasks.getByName('eclipseWtpFacet').finalizedBy 'installApps'
 
         //Create expected server extension from liberty extension data
         project.afterEvaluate {

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/AbstractServerTask.groovy
@@ -277,9 +277,9 @@ abstract class AbstractServerTask extends AbstractTask {
             if (appObj instanceof Task) {
                 application.appendNode('appsDirectory', appDir)
                 if (server.looseApplication) {
-                    application.appendNode('applicationFileName', appObj.archiveName + '.xml')
+                    application.appendNode('applicationFilename', appObj.archiveName + '.xml')
                 } else {
-                    application.appendNode('applicationFileName', appObj.archiveName)
+                    application.appendNode('applicationFilename', appObj.archiveName)
                 }
                 if (appObj instanceof War) {
                     application.appendNode('warSourceDirectory', project.webAppDirName)
@@ -287,9 +287,9 @@ abstract class AbstractServerTask extends AbstractTask {
             } else if (appObj instanceof File) {
                 application.appendNode('appsDirectory', appDir)
                 if (server.looseApplication) {
-                    application.appendNode('applicationFileName', appObj.name + '.xml')
+                    application.appendNode('applicationFilename', appObj.name + '.xml')
                 } else {
-                    application.appendNode('applicationFileName', appObj.name)
+                    application.appendNode('applicationFilename', appObj.name)
                 }
             }
 

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/AbstractServerTask.groovy
@@ -218,6 +218,7 @@ abstract class AbstractServerTask extends AbstractTask {
     }
 
     protected void setServerDirectoryNodes(Project project, Node serverNode) {
+        serverNode.appendNode('userDirectory', getUserDir(project).toString())
         serverNode.appendNode('serverDirectory', getServerDir(project).toString())
         String serverOutputDir = getServerOutputDir(project)
         if (serverOutputDir != null && !serverOutputDir.isEmpty()) {
@@ -332,7 +333,7 @@ abstract class AbstractServerTask extends AbstractTask {
 
         if (project.configurations.findByName('compile') && !project.configurations.compile.dependencies.isEmpty()) {
             project.configurations.compile.dependencies.each { dependency ->
-                serverNode.appendNode('projectCompileDepenency', dependency.group + ':' + dependency.name + ':' + dependency.version)
+                serverNode.appendNode('projectCompileDependency', dependency.group + ':' + dependency.name + ':' + dependency.version)
             }
         }
     }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallLibertyTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallLibertyTask.groovy
@@ -99,7 +99,6 @@ class InstallLibertyTask extends AbstractTask {
 
     protected void outputLibertyPropertiesToXml(MarkupBuilder xmlDoc) {
         xmlDoc.installDirectory (getInstallDir(project).toString())
-        xmlDoc.installAppPackages ('project')
 
         if (project.configurations.libertyRuntime != null) {
             project.configurations.libertyRuntime.dependencies.each { libertyArtifact ->

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallLibertyTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallLibertyTask.groovy
@@ -98,7 +98,6 @@ class InstallLibertyTask extends AbstractTask {
     }
 
     protected void outputLibertyPropertiesToXml(MarkupBuilder xmlDoc) {
-        xmlDoc.userDirectory (getUserDir(project).toString())
         xmlDoc.installDirectory (getInstallDir(project).toString())
         xmlDoc.installAppPackages ('project')
 


### PR DESCRIPTION
- Eclipse should now automatically build imported Gradle projects using this plugin
- Fixed some issues with the liberty-plugin-config.xml file