### PR TITLE
add input files to be copied over when calling libertyCreate #161

### DIFF
--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
@@ -116,12 +116,23 @@ class Liberty implements Plugin<Project> {
                 // Defining files set in build.gradle as inputs
                 if (!project.liberty.server.configFile.toString().equals('default')) {
                     inputs.file { project.liberty.server.configFile }
+                } else if (new File("${projectDir}/src/main/liberty/config/server.xml").exists()) {
+                    inputs.file { new File("${projectDir}/src/main/liberty/config/server.xml") }
                 }
                 if (!project.liberty.server.bootstrapPropertiesFile.toString().equals('default')) {
                     inputs.file { project.liberty.server.bootstrapPropertiesFile }
+                } else if (new File("${projectDir}/src/main/liberty/config/bootstrap.properties").exists()) {
+                    inputs.file { new File("${projectDir}/src/main/liberty/config/bootstrap.properties") }
                 }
                 if (!project.liberty.server.jvmOptionsFile.toString().equals('default')) {
                     inputs.file { project.liberty.server.jvmOptionsFile }
+                } else if (new File("${projectDir}/src/main/liberty/config/jvm.options").exists()) {
+                    inputs.file { new File("${projectDir}/src/main/liberty/config/jvm.options") }
+                }
+                if (!project.liberty.server.serverEnv.toString().equals('default')) {
+                    inputs.file { project.liberty.server.serverEnv }
+                } else if (new File("${projectDir}/src/main/liberty/config/server.env").exists()) {
+                    inputs.file { new File("${projectDir}/src/main/liberty/config/server.env") }
                 }
                 if (project.liberty.server.configDirectory.exists()) {
                     inputs.dir { project.liberty.server.configDirectory }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
@@ -113,8 +113,18 @@ class Liberty implements Plugin<Project> {
             dependsOn 'installLiberty'
 
             project.afterEvaluate{
+                // Defining files set in build.gradle as inputs
                 if (!project.liberty.server.configFile.toString().equals('default')) {
                     inputs.file { project.liberty.server.configFile }
+                }
+                if (!project.liberty.server.bootstrapPropertiesFile.toString().equals('default')) {
+                    inputs.file { project.liberty.server.bootstrapPropertiesFile }
+                }
+                if (!project.liberty.server.jvmOptionsFile.toString().equals('default')) {
+                    inputs.file { project.liberty.server.jvmOptionsFile }
+                }
+                if (project.liberty.server.configDirectory.exists()) {
+                    inputs.dir { project.liberty.server.configDirectory }
                 }
                 outputs.file { new File(getUserDir(project), "servers/${project.liberty.server.name}/server.xml") }
             }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
@@ -113,6 +113,9 @@ class Liberty implements Plugin<Project> {
             dependsOn 'installLiberty'
 
             project.afterEvaluate{
+                if (!project.liberty.server.configFile.toString().equals('default')) {
+                    inputs.file { project.liberty.server.configFile }
+                }
                 outputs.file { new File(getUserDir(project), "servers/${project.liberty.server.name}/server.xml") }
             }
         }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
@@ -112,29 +112,31 @@ class Liberty implements Plugin<Project> {
             group 'Liberty'
             dependsOn 'installLiberty'
 
-            project.afterEvaluate{
-                // Defining files set in build.gradle as inputs
+            project.afterEvaluate {
+                String defaultPath = project.projectDir.toString() + '/src/main/liberty/config/'
+
+                // Defining files set in build.gradle and check their default paths as inputs
                 if (!project.liberty.server.configFile.toString().equals('default')) {
                     inputs.file { project.liberty.server.configFile }
-                } else if (new File("${projectDir}/src/main/liberty/config/server.xml").exists()) {
-                    inputs.file { new File("${projectDir}/src/main/liberty/config/server.xml") }
+                } else if (new File(defaultPath + 'server.xml').exists()) {
+                    inputs.file { new File(defaultPath + 'server.xml') }
                 }
                 if (!project.liberty.server.bootstrapPropertiesFile.toString().equals('default')) {
                     inputs.file { project.liberty.server.bootstrapPropertiesFile }
-                } else if (new File("${projectDir}/src/main/liberty/config/bootstrap.properties").exists()) {
-                    inputs.file { new File("${projectDir}/src/main/liberty/config/bootstrap.properties") }
+                } else if (new File(defaultPath + 'bootstrap.properties').exists()) {
+                    inputs.file { new File(defaultPath + 'bootstrap.properties') }
                 }
                 if (!project.liberty.server.jvmOptionsFile.toString().equals('default')) {
                     inputs.file { project.liberty.server.jvmOptionsFile }
-                } else if (new File("${projectDir}/src/main/liberty/config/jvm.options").exists()) {
-                    inputs.file { new File("${projectDir}/src/main/liberty/config/jvm.options") }
+                } else if (new File(defaultPath + 'jvm.options').exists()) {
+                    inputs.file { new File(defaultPath + 'jvm.options') }
                 }
                 if (!project.liberty.server.serverEnv.toString().equals('default')) {
                     inputs.file { project.liberty.server.serverEnv }
-                } else if (new File("${projectDir}/src/main/liberty/config/server.env").exists()) {
-                    inputs.file { new File("${projectDir}/src/main/liberty/config/server.env") }
+                } else if (new File(defaultPath + 'server.env').exists()) {
+                    inputs.file { new File(defaultPath + 'server.env') }
                 }
-                if (project.liberty.server.configDirectory.exists()) {
+                if (project.liberty.server.configDirectory != null || project.liberty.server.configDirectory.exists()) {
                     inputs.dir { project.liberty.server.configDirectory }
                 }
                 outputs.file { new File(getUserDir(project), "servers/${project.liberty.server.name}/server.xml") }


### PR DESCRIPTION
Defines configFile, jvmOptionsFile, bootstrapPropertiesfile, serverEnv as inputs if set or if existing on their default paths. Additionally, configDirectory is added as an input directory if, and only if, set.
#161