### PR TITLE
removing old server elements from plugin-config.xml

### DIFF
--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/AbstractServerTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/AbstractServerTask.groovy
@@ -343,6 +343,9 @@ abstract class AbstractServerTask extends AbstractTask {
         Node libertyPluginConfig = pluginXmlParser.parse(new File(project.buildDir, 'liberty-plugin-config.xml'))
         if (libertyPluginConfig.getAt('servers').isEmpty()) {
             libertyPluginConfig.appendNode('servers')
+        } else {
+            //removes the server nodes from the servers element
+            libertyPluginConfig.getAt('servers')[0].value = ""
         }
         Node serverNode = new Node(null, 'server')
 


### PR DESCRIPTION
Old server elements were not getting removed from the plugin-config.xml file when the build file configuration was changed.

fixes #176 