### PR TITLE
applying eclipse-wtp earlier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ task wrapper(type: Wrapper) {
 
 archivesBaseName = 'liberty-gradle-plugin'
 group = 'net.wasdev.wlp.gradle.plugins'
-version = '2.3-SNAPSHOT'
+version = '2.2-SNAPSHOT'
 
 task sourcesJar(type: Jar) {
     classifier = 'sources'

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
@@ -56,6 +56,10 @@ class Liberty implements Plugin<Project> {
         project.configurations.create('libertyLicense')
         project.configurations.create('libertyRuntime')
 
+        //Used to set project facets in Eclipse
+        project.pluginManager.apply('eclipse-wtp')
+        project.tasks.getByName('eclipseWtpFacet').finalizedBy 'libertyCreate'
+
         //Create expected server extension from liberty extension data
         project.afterEvaluate {
             setEclipseFacets(project)
@@ -225,10 +229,6 @@ class Liberty implements Plugin<Project> {
     }
 
     private void setEclipseFacets(Project project) {
-        //Used to set project facets in Eclipse
-        project.pluginManager.apply('eclipse-wtp')
-        project.tasks.getByName('eclipseWtpFacet').finalizedBy 'libertyCreate'
-
         //Uplift the jst.web facet version to 3.0 if less than 3.0 so WDT can deploy properly to Liberty.
         //There is a known bug in the wtp plugin that will add duplicate facets, the first of the duplicates is honored.
         if(project.plugins.hasPlugin('war')) {


### PR DESCRIPTION
Lost ability to depend on eclipse plugin tasks because it was applied after the project was evaluated.