### PR TITLE
adding check for missing apps and dropins dirs

### DIFF
--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/NoAppsTemplateTest.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/NoAppsTemplateTest.groovy
@@ -1,0 +1,42 @@
+package net.wasdev.wlp.gradle.plugins;
+
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+
+public class NoAppsTemplateTest extends AbstractIntegrationTest{
+    static File resourceDir = new File("build/resources/integrationTest/sample.servlet")
+    static File buildDir = new File(integTestDir, "/no-apps-template-test")
+    static String buildFilename = "noAppsTemplateTest.gradle"
+
+    @BeforeClass
+    public static void setup() {
+        createDir(buildDir)
+        if(test_mode == "offline"){
+            WLP_DIR.replace("\\","/")
+        }
+        createTestProject(buildDir, resourceDir, buildFilename)
+    }
+
+    @Test
+    public void test_create_server_directory() {
+        try {
+            runTasks(buildDir, 'libertyCreate')
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task libertyCreate. "+ e)
+        }
+        assert new File(buildDir, 'build/wlp/usr/servers/testServer').exists() : 'testServer was not created'
+        assert new File(buildDir, 'build/wlp/usr/servers/testServer/apps').exists() : 'testServer/apps was not created'
+        assert new File(buildDir, 'build/wlp/usr/servers/testServer/dropins').exists() : 'testServer/dropins was not created'
+    }
+
+    @Test
+    public void test_app_installed_correctly() {
+        try {
+            runTasks(buildDir, 'installApps')
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task installApps. "+ e)
+        }
+        assert new File(buildDir, 'build/wlp/usr/servers/testServer/apps/sample.servlet-1.war').exists() : 'test app was not installed'
+    }
+}

--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/NoAppsTemplateTest.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/NoAppsTemplateTest.groovy
@@ -19,24 +19,15 @@ public class NoAppsTemplateTest extends AbstractIntegrationTest{
     }
 
     @Test
-    public void test_create_server_directory() {
-        try {
-            runTasks(buildDir, 'libertyCreate')
-        } catch (Exception e) {
-            throw new AssertionError ("Fail on task libertyCreate. "+ e)
-        }
-        assert new File(buildDir, 'build/wlp/usr/servers/testServer').exists() : 'testServer was not created'
-        assert new File(buildDir, 'build/wlp/usr/servers/testServer/apps').exists() : 'testServer/apps was not created'
-        assert new File(buildDir, 'build/wlp/usr/servers/testServer/dropins').exists() : 'testServer/dropins was not created'
-    }
-
-    @Test
     public void test_app_installed_correctly() {
         try {
             runTasks(buildDir, 'installApps')
         } catch (Exception e) {
             throw new AssertionError ("Fail on task installApps. "+ e)
         }
+        assert new File(buildDir, 'build/wlp/usr/servers/testServer').exists() : 'testServer was not created'
+        assert new File(buildDir, 'build/wlp/usr/servers/testServer/apps').exists() : 'testServer/apps was not created'
+        assert new File(buildDir, 'build/wlp/usr/servers/testServer/dropins').exists() : 'testServer/dropins was not created'
         assert new File(buildDir, 'build/wlp/usr/servers/testServer/apps/sample.servlet-1.war').exists() : 'test app was not installed'
     }
 }

--- a/src/integTest/resources/sample.servlet/noAppsTemplateTest.gradle
+++ b/src/integTest/resources/sample.servlet/noAppsTemplateTest.gradle
@@ -1,0 +1,45 @@
+group = 'liberty.gradle'
+version = '1'
+
+apply plugin: 'war'
+apply plugin: 'liberty'
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven {
+            name = 'Sonatype Nexus Snapshots'
+            url = 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
+    }
+    dependencies {
+        classpath group: 'net.wasdev.wlp.gradle.plugins', name: 'liberty-gradle-plugin', version: lgpVersion
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.apache.cxf:cxf-rt-rs-client:3.1.1'
+    testCompile 'org.glassfish:javax.json:1.0.4'
+    providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'
+    libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-webProfile7', version: wlpVersion
+}
+
+liberty {
+    server {
+        configFile = file("src/main/liberty/config/server-apps-test.xml")
+
+        name = 'testServer'
+        looseApplication = false
+
+        template = 'webProfile7'
+
+        apps = [war]
+    }
+}

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/CreateTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/CreateTask.groovy
@@ -75,7 +75,6 @@ class CreateTask extends AbstractServerTask {
                 params.put('template', server.template)
             }
             executeServerCommand(project, 'create', params)
-            createApplicationFolders()
         }
         copyConfigFiles()
         writeServerPropertiesToXml(project)
@@ -88,20 +87,6 @@ class CreateTask extends AbstractServerTask {
             return new File(server.configDirectory, fileName)
         } else if (new File(DEFAULT_PATH + fileName).exists()) {
             return new File(DEFAULT_PATH + fileName)
-        }
-    }
-
-    void createApplicationFolders() {
-        File serverDir = getServerDir(project)
-        File appsDirectory = new File(serverDir, 'apps')
-        File dropinsDirectory = new File(serverDir, 'dropins')
-
-        if (!appsDirectory.exists()) {
-            appsDirectory.mkdir()
-        }
-
-        if (!dropinsDirectory.exists()) {
-            dropinsDirectory.mkdir()
         }
     }
 }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/CreateTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/CreateTask.groovy
@@ -75,6 +75,7 @@ class CreateTask extends AbstractServerTask {
                 params.put('template', server.template)
             }
             executeServerCommand(project, 'create', params)
+            createApplicationFolders()
         }
         copyConfigFiles()
         writeServerPropertiesToXml(project)
@@ -87,6 +88,20 @@ class CreateTask extends AbstractServerTask {
             return new File(server.configDirectory, fileName)
         } else if (new File(DEFAULT_PATH + fileName).exists()) {
             return new File(DEFAULT_PATH + fileName)
+        }
+    }
+
+    void createApplicationFolders() {
+        File serverDir = getServerDir(project)
+        File appsDirectory = new File(serverDir, 'apps')
+        File dropinsDirectory = new File(serverDir, 'dropins')
+
+        if (!appsDirectory.exists()) {
+            appsDirectory.mkdir()
+        }
+
+        if (!dropinsDirectory.exists()) {
+            dropinsDirectory.mkdir()
         }
     }
 }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallAppsTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallAppsTask.groovy
@@ -59,6 +59,9 @@ class InstallAppsTask extends AbstractServerTask {
                 server.apps = [project.ear]
             }
         }
+
+        createApplicationFolders()
+
         if (server.apps != null && !server.apps.isEmpty()) {
             Tuple appsLists = splitAppList(server.apps)
             installMultipleApps(appsLists[0], 'apps')
@@ -377,5 +380,23 @@ class InstallAppsTask extends AbstractServerTask {
             return appXml.hasChildElements()
         }
         return false
+    }
+
+    void createApplicationFolders() {
+        File serverDir = getServerDir(project)
+        File appsDirectory = new File(serverDir, 'apps')
+        File dropinsDirectory = new File(serverDir, 'dropins')
+
+        try {
+            if (!appsDirectory.exists()) {
+                appsDirectory.mkdir()
+            }
+
+            if (!dropinsDirectory.exists()) {
+                dropinsDirectory.mkdir()
+            }
+        } catch (Exception e) {
+            throw new GradleException('There was a problem creating the apps or dropins folder in the server directory.', e)
+        }
     }
 }


### PR DESCRIPTION
Creating missing apps and dropins folders if server directory was created from a template that does not include these folders.
Fixes #246 