### PR TITLE
refactoring integration test property files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: java
 jdk:
     - openjdk8
 env:
-    - propertiesFile=wlp1.properties
-    - propertiesFile=wlp2.properties
-    - propertiesFile=ol1.properties
-    - propertiesFile=ol2.properties
+    - RUNTIME=wlp RUNTIME_VERSION=17.0.0.4
+    - RUNTIME=wlp RUNTIME_VERSION=18.0.0.1
+    - RUNTIME=ol RUNTIME_VERSION=17.0.0.4
+    - RUNTIME=ol RUNTIME_VERSION=18.0.0.1
 script:
   - export GRADLE_OPTS="-Dorg.gradle.daemon=true -Dorg.gradle.jvmargs='-XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx2048m'"
-  - travis_wait ./gradlew install integrationTest -DpropertiesFile=${propertiesFile} --stacktrace --info --no-daemon
+  - travis_wait ./gradlew install integrationTest -Druntime=$RUNTIME -DruntimeVersion=$RUNTIME_VERSION --stacktrace --info --no-daemon
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Clone this repository and then, with a JRE on the path, execute the following co
 $ ./gradlew build
 ```
 
-This will download Gradle and then build the plugin `liberty-gradle-plugin-2.3-SNAPSHOT.jar` in to the `build\libs` directory. It is also possible to install the plugin in to your local Maven repository using `./gradlew install`.
+This will download Gradle, build the plugin, and install it in to the `build\libs` directory. It is also possible to install the plugin in to your local Maven repository using `./gradlew install`.
 
-To build the plugin and run the integration tests execute the following commands in the root directory. The `propertiesFile` parameter is used to select the Liberty runtime that will be used to run the tests. The `wlpLicense` parameter is only needed for Liberty packaged as a JAR file.
+To build the plugin and run the integration tests execute the following commands in the root directory. The `runtime` and `runtimeVersion` parameters are used to select the Liberty runtime that will be used to run the tests. The `wlpLicense` parameter is only needed for Liberty packaged as a JAR file.
 
  ```bash
- $ ./gradlew install integrationTest -DpropertiesFile=<property_file_name> -DwlpLicense=<liberty_license_code>
+ $ ./gradlew install integrationTest -Druntime=<wlp|ol> -DruntimeVersion=<runtime_version> -DwlpLicense=<liberty_license_code>
  ```
 
 ## Usage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,20 @@
 environment:
     matrix:
         - jdk: "C:\\Program Files\\Java\\jdk1.8.0\\bin:"
-          PROPERTIES_FILE: wlp1.properties
+          RUNTIME: wlp
+          RUNTIME_VERSION: 17.0.0.4
         - jdk: "C:\\Program Files\\Java\\jdk1.8.0\\bin:"
-          PROPERTIES_FILE: wlp2.properties
+          RUNTIME: wlp
+          RUNTIME_VERSION: 18.0.0.1
         - jdk: "C:\\Program Files\\Java\\jdk1.8.0\\bin:"
-          PROPERTIES_FILE: ol1.properties
+          RUNTIME: ol
+          RUNTIME_VERSION: 17.0.0.4
         - jdk: "C:\\Program Files\\Java\\jdk1.8.0\\bin:"
-          PROPERTIES_FILE: ol2.properties
+          RUNTIME: ol
+          RUNTIME_VERSION: 18.0.0.1
 
 build_script:
   # Build the compiled extension
-  - "gradlew.bat install integrationTest -DpropertiesFile=%PROPERTIES_FILE% --stacktrace --info --no-daemon"
+  - "gradlew.bat install integrationTest -Druntime=%RUNTIME% -DruntimeVersion=%RUNTIME_VERSION% --stacktrace --info --no-daemon"
 
 test: off

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,8 @@
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.OutputStream
+import java.util.Properties
+
 apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'signing'
@@ -81,10 +86,54 @@ task integrationTest(type: Test) {
     systemProperties System.getProperties()
     systemProperty 'runit', 'online'
 
-    String libertyPropertiesFile = System.getProperty('propertiesFile')
     doFirst {
-        if (libertyPropertiesFile == null || libertyPropertiesFile.isEmpty()) {
-            throw new GradleException('Tests could not be run. Please specify a properties file.')
+
+        String runtimeGroup
+        String runtimeArtifactId
+        String libertyRuntime = System.getProperty('runtime')
+        String runtimeVersion = System.getProperty('runtimeVersion')
+
+        if (libertyRuntime == null || libertyRuntime.isEmpty()) {
+            throw new GradleException('Tests could not be run. Please specify a Liberty runtime. Choose either wlp or ol.')
+        }
+        if (runtimeVersion == null || runtimeVersion.isEmpty()) {
+            throw new GradleException('Tests could not be run. Please specify a Liberty runtime version.')
+        }
+        
+        Properties prop = new Properties()
+        OutputStream output = null
+
+        try {
+
+        output = new FileOutputStream("${buildDir}/gradle.properties");
+
+        if (libertyRuntime == "ol") {
+            runtimeGroup = "io.openliberty"
+            runtimeArtifactId = "openliberty-runtime"
+        } else {
+            runtimeGroup = "com.ibm.websphere.appserver.runtime"
+            runtimeArtifactId = "wlp-javaee7"
+        }
+
+        // set the properties value
+        prop.setProperty("lgpVersion", version)
+        prop.setProperty("runtimeGroup", runtimeGroup)
+        prop.setProperty("runtimeArtifactId", runtimeArtifactId)
+        prop.setProperty("runtimeVersion", runtimeVersion)
+
+        // save properties to project root folder
+        prop.store(output, null)
+
+        } catch (IOException io) {
+            io.printStackTrace()
+        } finally {
+            if (output != null) {
+                try {
+                    output.close()
+                } catch (IOException e) {
+                    e.printStackTrace()
+                }
+            }
         }
     }
 }

--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/AbstractIntegrationTest.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/AbstractIntegrationTest.groovy
@@ -28,15 +28,7 @@ import org.gradle.api.GradleException
 
 abstract class AbstractIntegrationTest {
 
-    public static final String LIBERTY_PROPERTIES_FILENAME_1 = 'wlp1.properties'
-    public static final String LIBERTY_PROPERTIES_FILENAME_2 = 'wlp2.properties'
-    public static final String OPEN_LIBERTY_PROPERTIES_FILENAME_1 = 'ol1.properties'
-    public static final String OPEN_LIBERTY_PROPERTIES_FILENAME_2 = 'ol2.properties'
-
-    public static final String PROPERTY_FILE_DIRECTORY = "src/integTest/properties"
-
     static File integTestDir = new File('build/testBuilds')
-    static String libertyProperties = System.getProperty("propertiesFile")
 
     protected static void deleteDir(File dir) {
         if (dir.exists()) {
@@ -56,30 +48,7 @@ abstract class AbstractIntegrationTest {
 
     protected static File copyBuildFiles(File buildFilename, File buildDir) {
         copyFile(buildFilename, new File(buildDir, 'build.gradle'))
-        copyPropertyFile(buildDir)
-    }
-
-    protected static void copyPropertyFile(File buildDir) {
-        File propertyFile
-        if (libertyProperties != null) {
-            switch (libertyProperties) {
-                case LIBERTY_PROPERTIES_FILENAME_2:
-                    propertyFile = new File(PROPERTY_FILE_DIRECTORY, LIBERTY_PROPERTIES_FILENAME_2)
-                    break;
-                case OPEN_LIBERTY_PROPERTIES_FILENAME_1:
-                    propertyFile = new File(PROPERTY_FILE_DIRECTORY, OPEN_LIBERTY_PROPERTIES_FILENAME_1)
-                    break;
-                case OPEN_LIBERTY_PROPERTIES_FILENAME_2:
-                    propertyFile = new File(PROPERTY_FILE_DIRECTORY, OPEN_LIBERTY_PROPERTIES_FILENAME_2)
-                    break;
-                default:
-                    propertyFile = new File(PROPERTY_FILE_DIRECTORY, LIBERTY_PROPERTIES_FILENAME_1)
-                    break;
-            }
-        } else {
-            throw new GradleException('Tests could not be run. Please specify a properties file.')
-        }
-        copyFile(propertyFile, new File(buildDir, 'gradle.properties'))
+        copyFile(new File("build/gradle.properties"), new File(buildDir, 'gradle.properties'))
     }
 
     protected static File createTestProject(File parent, File sourceDir, String buildFilename) {

--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/ConfigureArquillianTest.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/ConfigureArquillianTest.groovy
@@ -40,7 +40,7 @@ class ConfigureArquillianTest extends AbstractIntegrationTest {
     public static void setup() {
         createDir(buildDir)
         FileUtils.copyDirectory(resourceDir, buildDir);
-        copyPropertyFile(buildDir)
+        copyFile(new File("build/gradle.properties"), new File(buildDir, 'gradle.properties'))
     }
 
     @Test

--- a/src/integTest/properties/ol1.properties
+++ b/src/integTest/properties/ol1.properties
@@ -1,4 +1,0 @@
-lgpVersion=2.3.1-SNAPSHOT
-runtimeVersion=17.0.0.4
-runtimeArtifactId=openliberty-runtime
-runtimeGroup=io.openliberty

--- a/src/integTest/properties/ol2.properties
+++ b/src/integTest/properties/ol2.properties
@@ -1,4 +1,0 @@
-lgpVersion=2.3.1-SNAPSHOT
-runtimeVersion=18.0.0.1
-runtimeArtifactId=openliberty-runtime
-runtimeGroup=io.openliberty

--- a/src/integTest/properties/wlp1.properties
+++ b/src/integTest/properties/wlp1.properties
@@ -1,4 +1,0 @@
-lgpVersion=2.3.1-SNAPSHOT
-runtimeVersion=17.0.0.4
-runtimeArtifactId=wlp-javaee7
-runtimeGroup=com.ibm.websphere.appserver.runtime

--- a/src/integTest/properties/wlp2.properties
+++ b/src/integTest/properties/wlp2.properties
@@ -1,4 +1,0 @@
-lgpVersion=2.3.1-SNAPSHOT
-runtimeVersion=18.0.0.1
-runtimeArtifactId=wlp-javaee7
-runtimeGroup=com.ibm.websphere.appserver.runtime


### PR DESCRIPTION
Changed integration test parameters to be the same as the Maven plugin.
Plugin now generates a gradle.properties file in the build directory to use for the integration tests.