### PR TITLE
Update readmes for features and Liberty 18.0.0.2 artifacts

### DIFF
--- a/docs/installFeature.md
+++ b/docs/installFeature.md
@@ -12,7 +12,7 @@ In Open Liberty runtime versions 18.0.0.1 and below, this task will be skipped. 
 
 ### Dependencies
 
-The Liberty Gradle plugin defines the `libertyFeature` dependency configuration for installing features. If the `java` plugin is applied in the build, then the `libertyFeature` configuration extends from the `java` plugin's `compileOnly` configuration to provide WebSphere Application Server Liberty API, SPI, and  Java specification dependencies.
+The Liberty Gradle plugin defines the `libertyFeature` dependency configuration for installing features. If the `java` plugin is applied in the build, then the `libertyFeature` configuration extends from the `java` plugin's `compileOnly` configuration to provide Liberty API, SPI, and  Java specification dependencies.
 
 The `libertyFeature` dependency configuration can install features in Liberty runtime versions 18.0.0.2 and above. Use the `io.openliberty.features` group for Open Liberty features, or the `com.ibm.websphere.appserver.features` group for WebSphere Liberty features.
 

--- a/docs/installFeature.md
+++ b/docs/installFeature.md
@@ -1,7 +1,22 @@
 ## installFeature task
-The `installFeature` task installs features packaged as a Subsystem Archive (ESA file) to the Liberty runtime. The `installFeature` task can install a list of features to the Liberty runtime, or it can install a set of features based on the server configuration file.
-  
-This goal is not supported if the Liberty runtime is installed from the Open Liberty runtime package. You will get a missing file error since the `bin/installUtiltiy` command is removed from the Open Liberty runtime package. The Open Liberty runtime is always bundled with all applicable features and there isn't any need to install any additional feature.  
+The `installFeature` task installs features packaged as a Subsystem Archive (ESA file) to the Liberty runtime. 
+
+In Open Liberty and WebSphere Liberty runtime versions 18.0.0.2 and above, this task can install features specified in the following ways:
+* Using the `libertyFeature` dependency configuration,
+* features listed in the `name` attribute,
+* features declared in the `server.xml` file, its `include` elements, and from additional configuration files in the `configDropins` directory.
+
+In WebSphere Liberty runtime versions 18.0.0.1 and below, this task will install features specified in the `name` attribute. To install the missing features declared in the `server.xml` file (including its `include` elements, and from additional configuration files in the `configDropins` directory), set the `acceptLicense` attribute to `true` but do not specify any `name` attribute.
+
+In Open Liberty runtime versions 18.0.0.1 and below, this task will be skipped. A warning message will be displayed. The Open Liberty runtime versions 18.0.0.1 and below are bundled with all applicable features. There is no need to install or uninstall additional features.
+
+### Dependencies
+
+The Liberty Gradle plugin defines the `libertyFeature` dependency configuration for installing features. If the `java` plugin is applied in the build, then the `libertyFeature` configuration extends from the `java` plugin's `compileOnly` configuration to provide WebSphere Application Server Liberty API, SPI, and  Java specification dependencies.
+
+The `libertyFeature` dependency configuration can install features in Liberty runtime versions 18.0.0.2 and above. Use the `io.openliberty.features` group for Open Liberty features, or the `com.ibm.websphere.appserver.features` group for WebSphere Liberty features.
+
+You need to include `group`, `name`, and `version` values that describes the artifacts to use. An `ext` value for the ESA file type is not required.
 
 ### dependsOn
 `installFeature` depends on `installLiberty`. If no specific features are requested, `installFeature` depends on `libertyCreate` to evaluate the set of features in the server configuration file.
@@ -53,7 +68,47 @@ liberty {
 }
 ```
 
-3. The following uses the server's `server.xml` file to install all configured features.
+3. Install features from dependencies in Liberty runtime versions 18.0.0.2 and above.
+
+* Open Liberty features:
+```groovy
+apply plugin: 'liberty'
+
+dependencies {
+    libertyFeature 'io.openliberty.features:jaxrs-2.1:18.0.0.2'
+    libertyFeature 'io.openliberty.features:jsonp-1.1:18.0.0.2'
+}
+
+liberty {
+
+    server {
+        features {
+            acceptLicense = true
+        }
+    }
+}
+```
+
+* WebSphere Liberty features:
+```groovy
+apply plugin: 'liberty'
+
+dependencies {
+    libertyFeature 'com.ibm.websphere.appserver.features:servlet-3.0:18.0.0.2'
+    libertyFeature 'io.openliberty.features:localConnector-1.0:18.0.0.2'
+}
+
+liberty {
+
+    server {
+        features {
+            acceptLicense = true
+        }
+    }
+}
+```
+
+4. The following uses the server's `server.xml` file to install all configured features.
 ```groovy
 /* Install all features configured by the server */
 apply plugin: 'liberty'

--- a/docs/installLiberty.md
+++ b/docs/installLiberty.md
@@ -14,7 +14,7 @@ Note: Use the `libertyRuntime` dependency to install Liberty from The Central Re
 
 ### Dependencies
 
-The Liberty Gradle plugin defines two dependency configurations for the `installLiberty` task: `libertyRuntime` and `libertyLicense`.  `libertyRuntime` defines which [WebSphere Liberty runtime](#using-maven-artifact) to download from The Central Repository. `libertyLicense` [configures](#license-configuration) a license artifact so that your license JAR archive can be identified and used during the `installLiberty` task. Make sure to properly [setup](#installing-your-upgrade-license) your license JAR to prevent a missing dependency failure.
+The Liberty Gradle plugin defines two dependency configurations for the `installLiberty` task: `libertyRuntime` and `libertyLicense`.  `libertyRuntime` defines which [Liberty runtime](#using-maven-artifact) to download from The Central Repository. `libertyLicense` [configures](#license-configuration) a license artifact so that your license JAR archive can be identified and used during the `installLiberty` task. Make sure to properly [setup](#installing-your-upgrade-license) your license JAR to prevent a missing dependency failure.
 
 You need to include `group`, `name`, and `version` values that describes the artifacts to use. An `ext` value for a specific archive type can be used but is not required.
 

--- a/docs/installLiberty.md
+++ b/docs/installLiberty.md
@@ -14,7 +14,7 @@ Note: Use the `libertyRuntime` dependency to install Liberty from The Central Re
 
 ### Dependencies
 
-The Liberty Gradle plugin defines two dependency configurations: `libertyRuntime` and `libertyLicense`.  `libertyRuntime` defines which [WebSphere Liberty runtime](#using-maven-artifact) to download from The Central Repository. `libertyLicense` [configures](#license-configuration) a license artifact so that your license JAR archive can be identified and used during the `installLiberty` task. Make sure to properly [setup](#installing-your-upgrade-license) your license JAR to prevent a missing dependency failure.
+The Liberty Gradle plugin defines two dependency configurations for the `installLiberty` task: `libertyRuntime` and `libertyLicense`.  `libertyRuntime` defines which [WebSphere Liberty runtime](#using-maven-artifact) to download from The Central Repository. `libertyLicense` [configures](#license-configuration) a license artifact so that your license JAR archive can be identified and used during the `installLiberty` task. Make sure to properly [setup](#installing-your-upgrade-license) your license JAR to prevent a missing dependency failure.
 
 You need to include `group`, `name`, and `version` values that describes the artifacts to use. An `ext` value for a specific archive type can be used but is not required.
 
@@ -105,15 +105,28 @@ Use the [dependencies block](#dependencies) to specify the name of the repositor
 
 The Maven Central repository includes the following Liberty runtime artifacts:
 
+##### Open Liberty  
+The `group` value for all the artifacts listed below is `io.openliberty`.
+
 |`name` | Versions | Description |
 | --- | ----------------- | ----------- |
-| [wlp-javaee7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-javaee7/) | 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with all Java EE 7 Full Platform features. |
-| [wlp-webProfile7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile7/) | 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with Java EE 7 Web Profile features. |
-| [wlp-kernel](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-kernel/) | 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime kernel. |
-| [wlp-osgi](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-osgi/) | 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime with features that support OSGi applications. |
-| [wlp-microProfile1](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-microProfile1/) | 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3 | Liberty with features for a MicroProfile runtime. |
+| [openliberty-runtime](https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/) | 18.0.0.2, 18.0.0.1, 17.0.0.4, 17.0.0.3 | Open Liberty runtime. |
+| [openliberty-javaee8](https://repo1.maven.org/maven2/io/openliberty/openliberty-javaee8/) | 18.0.0.2 | Open Liberty runtime with all Java EE 8 Full Platform features. |
+| [openliberty-webProfile8](https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile8/) | 18.0.0.2 | Open Liberty runtime with Java EE 8 Web Profile features. |
+| [openliberty-kernel](https://repo1.maven.org/maven2/io/openliberty/openliberty-kernel/) | 18.0.0.2 | Open Liberty runtime kernel. |
 
-The `group` value for all the artifacts listed above is `com.ibm.websphere.appserver.runtime`.
+##### WebSphere Liberty  
+The `group` value for all the artifacts listed below is `com.ibm.websphere.appserver.runtime`.
+
+|`name` | Versions | Description |
+| --- | ----------------- | ----------- |
+| [wlp-javaee8](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-javaee8/) | 18.0.0.2 | WebSphere Liberty runtime with all Java EE 8 Full Platform features. |
+| [wlp-javaee7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-javaee7/) | 18.0.0.2, 18.0.0.1, 17.0.0.4, 17.0.0.3, 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | WebSphere Liberty runtime with all Java EE 7 Full Platform features. |
+| [wlp-webProfile8](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile8/) | 18.0.0.2 | WebSphere Liberty runtime with Java EE 8 Web Profile features. |
+| [wlp-webProfile7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile7/) | 18.0.0.2, 18.0.0.1, 17.0.0.4, 17.0.0.3, 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | WebSphere Liberty runtime with Java EE 7 Web Profile features. |
+| [wlp-kernel](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-kernel/) | 18.0.0.2, 18.0.0.1, 17.0.0.4, 17.0.0.3, 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | WebSphere Liberty runtime kernel. |
+| [wlp-osgi](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-osgi/) | 18.0.0.2, 18.0.0.1, 17.0.0.4, 17.0.0.3, 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | WebSphere Liberty runtime with features that support OSGi applications. |
+| [wlp-microProfile1](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-microProfile1/) | 18.0.0.2, 18.0.0.1, 17.0.0.4, 17.0.0.3, 17.0.0.2, 17.0.0.1, 16.0.0.4, 16.0.0.3 | WebSphere Liberty with features for a MicroProfile runtime. |
 
 ### Installing your upgrade license
 To upgrade the runtime license, the Liberty license JAR file, which is available to download from IBM Fix Central or the Passport Advantage website, must be installed into a local repository or a protected internal repository. After successful installation, add your license artifact to your Liberty block in your `build.gradle` file to upgrade the license during the `installLiberty` task.

--- a/docs/uninstallFeature.md
+++ b/docs/uninstallFeature.md
@@ -1,6 +1,8 @@
 ## uninstallFeature task
 The `uninstallFeature` task uninstalls a feature from the Liberty runtime.
 
+This task will be skipped in versions of the Open Liberty runtime that do not include `bin/installUtility`. A warning message will be displayed. The Open Liberty runtime versions 18.0.0.1 and below are bundled with all applicable features, so there is no need to install or uninstall additional features. In version 18.0.0.2, Open Liberty is available as different [runtime artifacts](installLiberty.md#using-maven-artifact) with their corresponding features and does not support uninstalling features.
+
 ### dependsOn
 `uninstallFeature` depends on `libertyCreate` to make sure a server exists. 
 


### PR DESCRIPTION
Update readmes for installing features from dependencies. Include additional runtimes in list of artifacts.