### PR TITLE
Add test for installing features twice with lowercase

### DIFF
--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/KernelInstallFeatureTest.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/KernelInstallFeatureTest.groovy
@@ -183,6 +183,28 @@ class KernelInstallFeatureTest extends AbstractIntegrationTest{
         assertNotInstalled("distributedMap-1.0")
     }
     
+    @Test
+    /**
+     * Install with server.xml features specified in lowercase and were already installed
+     */
+    public void testInstallFeaturesServerAlreadyInstalledLowercase() {
+        copyBuildFiles(new File(resourceDir, "install_features_server.gradle"), buildDir)
+        runTasks(buildDir, "libertyCreate")
+        copyServer("server_lowercase.xml")
+        
+        runTasks(buildDir, "installFeature")
+        assertInstalled("appSecurityClient-1.0")
+        assertInstalled("beanValidation-2.0")
+        assertNotInstalled("couchdb-1.0")
+        assertNotInstalled("distributedMap-1.0")
+        
+        runTasks(buildDir, "installFeature")
+        assertInstalled("appSecurityClient-1.0")
+        assertInstalled("beanValidation-2.0")
+        assertNotInstalled("couchdb-1.0")
+        assertNotInstalled("distributedMap-1.0")
+    }
+    
     private copyServer(String serverFile) {
         copyFile(new File(resourceDir, serverFile), new File(buildDir, "build/wlp/usr/servers/dummy/server.xml"))
     }

--- a/src/integTest/resources/kernel-install-feature-test/server_lowercase.xml
+++ b/src/integTest/resources/kernel-install-feature-test/server_lowercase.xml
@@ -1,0 +1,6 @@
+<server description="default server">
+    <featureManager>    
+        <feature>appsecurityclient-1.0</feature>
+        <feature>beanvalidation-2.0</feature>
+    </featureManager>     
+</server>


### PR DESCRIPTION
Add integration test to cover the scenario described in WASdev/ci.common#17 which occurs when features are specified with lowercase.