### PR TITLE
Up wait times & align test method names with alpha order.  

### DIFF
--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/LibertyTest.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/LibertyTest.groovy
@@ -39,6 +39,36 @@ class LibertyTest extends AbstractIntegrationTest{
             throw new AssertionError ("Fail on task installLiberty. "+ e)
         }
     }
+        
+    @Test
+    public void test0_run() {
+        final int timeout = 120000     // 120 sec, but polling will break out earlier typically
+        final String START_SERVER_MESSAGE_REGEXP = "CWWKF0011I.*"
+
+        ServerTask st = new ServerTask()
+        def installDir = new File(buildDir.getAbsolutePath() + "/build/wlp")
+        st.setInstallDir(installDir)
+        st.setServerName('LibertyProjectServer')
+        st.initTask()
+
+        try{
+            def stop_thread = Thread.start {
+                String verify = st.waitForStringInLog(START_SERVER_MESSAGE_REGEXP, timeout, st.getLogFile())
+                try {
+                    if (verify) {
+                        runTasks(buildDir, 'libertyStop')
+                    } else {
+                        throw new AssertionError ("Fail to start server for libertyRun.")
+                    }
+                } catch (Exception e) {
+                    throw new AssertionError ("Fail on task libertyStop for libertyRun. "+e)
+                }
+            }
+            runTasks(buildDir, 'libertyRun')
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task libertyRun. "+e)
+        }
+    }
 
     @Test
     public void test1_start() {
@@ -121,34 +151,5 @@ class LibertyTest extends AbstractIntegrationTest{
         }
     }
 
-    @Test
-    public void test10_run() {
-        final int timeout = 30000     // 30 sec
-        final String START_SERVER_MESSAGE_REGEXP = "CWWKF0011I.*"
-
-        ServerTask st = new ServerTask()
-        def installDir = new File(buildDir.getAbsolutePath() + "/build/wlp")
-        st.setInstallDir(installDir)
-        st.setServerName('LibertyProjectServer')
-        st.initTask()
-
-        try{
-            def stop_thread = Thread.start {
-                String verify = st.waitForStringInLog(START_SERVER_MESSAGE_REGEXP, timeout, st.getLogFile())
-                try {
-                    if (verify) {
-                        runTasks(buildDir, 'libertyStop')
-                    } else {
-                        throw new AssertionError ("Fail to start server for libertyRun.")
-                    }
-                } catch (Exception e) {
-                    throw new AssertionError ("Fail on task libertyStop for libertyRun. "+e)
-                }
-            }
-            runTasks(buildDir, 'libertyRun')
-        } catch (Exception e) {
-            throw new AssertionError ("Fail on task libertyRun. "+e)
-        }
-    }
 
 }

--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/OldLibertyTest.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/OldLibertyTest.groovy
@@ -41,6 +41,36 @@ class OldLibertyTest extends AbstractIntegrationTest{
     }
 
     @Test
+    public void test0_run() {
+        final int timeout = 120000     // 120 sec, but polling will break out earlier typically
+        final String START_SERVER_MESSAGE_REGEXP = "CWWKF0011I.*"
+
+        ServerTask st = new ServerTask()
+        def installDir = new File(buildDir.getAbsolutePath() + "/build/wlp")
+        st.setInstallDir(installDir)
+        st.setServerName('LibertyProjectServer')
+        st.initTask()
+
+        try{
+            def stop_thread = Thread.start {
+                String verify = st.waitForStringInLog(START_SERVER_MESSAGE_REGEXP, timeout, st.getLogFile())
+                try {
+                    if (verify) {
+                        runTasks(buildDir, 'libertyStop')
+                    } else {
+                        throw new AssertionError ("Fail to start server for libertyRun.")
+                    }
+                } catch (Exception e) {
+                    throw new AssertionError ("Fail on task libertyStop for libertyRun. "+e)
+                }
+            }
+            runTasks(buildDir, 'libertyRun')
+        } catch (Exception e) {
+            throw new AssertionError ("Fail on task libertyRun. "+e)
+        }
+    }
+    
+    @Test
     public void test1_start() {
         try {
             runTasks(buildDir, 'libertyStart')
@@ -121,34 +151,6 @@ class OldLibertyTest extends AbstractIntegrationTest{
         }
     }
 
-    @Test
-    public void test10_run() {
-        final int timeout = 30000     // 30 sec
-        final String START_SERVER_MESSAGE_REGEXP = "CWWKF0011I.*"
 
-        ServerTask st = new ServerTask()
-        def installDir = new File(buildDir.getAbsolutePath() + "/build/wlp")
-        st.setInstallDir(installDir)
-        st.setServerName('LibertyProjectServer')
-        st.initTask()
-
-        try{
-            def stop_thread = Thread.start {
-                String verify = st.waitForStringInLog(START_SERVER_MESSAGE_REGEXP, timeout, st.getLogFile())
-                try {
-                    if (verify) {
-                        runTasks(buildDir, 'libertyStop')
-                    } else {
-                        throw new AssertionError ("Fail to start server for libertyRun.")
-                    }
-                } catch (Exception e) {
-                    throw new AssertionError ("Fail on task libertyStop for libertyRun. "+e)
-                }
-            }
-            runTasks(buildDir, 'libertyRun')
-        } catch (Exception e) {
-            throw new AssertionError ("Fail on task libertyRun. "+e)
-        }
-    }
 
 }


### PR DESCRIPTION
Increasing the wait times is obvious.. this seems to be a common issue for me on my local Windows machine, and an occasional issue in automated builds.

Rename/reordering methods is just for better comprehension.  Since the order in general matters, it's weird to have test10, test1, test2,   because of the numeric value of "_".