### PR TITLE
InstallLiberty output update

### DIFF
--- a/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/InstallDirSubProject.groovy
+++ b/src/integTest/groovy/net/wasdev/wlp/gradle/plugins/InstallDirSubProject.groovy
@@ -1,0 +1,59 @@
+/*
+ * (C) Copyright IBM Corporation 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.wasdev.wlp.gradle.plugins
+
+import static org.junit.Assert.*
+
+import org.junit.BeforeClass
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.runners.MethodSorters
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class InstallDirSubProject extends AbstractIntegrationTest {
+    static File resourceDir = new File("build/resources/integrationTest/sub-project-test")
+    static File buildDir = new File(integTestDir, "/InstallDirSubProject")
+    static String buildFilename = "install_dir_sub_project.gradle"
+
+    static File runtimeInstallDir = new File(buildDir, 'wlp')
+    static File parentProjectBuildDir = new File(buildDir, 'build')
+    static File subProjectBuildDir = new File(buildDir, 'webapp/build')
+
+    @BeforeClass
+    public static void setup() {
+        createDir(buildDir)
+        createTestProject(buildDir, resourceDir, buildFilename)
+    }
+
+    @Test
+    void testProjectDirectoriesBeforeClean() {
+        runTasks(buildDir, 'libertyCreate')
+        assert runtimeInstallDir.exists()
+        assert parentProjectBuildDir.exists()
+        assert new File(parentProjectBuildDir, "liberty-plugin-config.xml").exists()
+        assert subProjectBuildDir.exists()
+        assert new File(subProjectBuildDir, "liberty-plugin-config.xml").exists()
+    }
+
+    @Test
+    void testProjectDirectoriesPostClean() {
+        runTasks(buildDir, "clean", "libertyCreate")
+        assert parentProjectBuildDir.exists()
+        assert new File(parentProjectBuildDir, "liberty-plugin-config.xml").exists()
+        assert subProjectBuildDir.exists()
+        assert new File(subProjectBuildDir, "liberty-plugin-config.xml").exists()
+    }
+}

--- a/src/integTest/resources/sub-project-test/install_dir_sub_project.gradle
+++ b/src/integTest/resources/sub-project-test/install_dir_sub_project.gradle
@@ -1,0 +1,35 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+        maven {
+            name = 'Sonatype Nexus Snapshots'
+            url = 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
+    }
+
+    dependencies {
+        classpath group: 'net.wasdev.wlp.gradle.plugins', name: 'liberty-gradle-plugin', version: lgpVersion
+    }
+}
+
+allprojects {
+    apply plugin: 'base'
+    apply plugin: 'liberty'
+
+    liberty {
+        install {
+            baseDir = rootProject.projectDir
+        }
+    }
+
+    repositories {
+        addAll rootProject.buildscript.repositories
+    }
+}
+
+dependencies {
+    libertyRuntime "io.openliberty:openliberty-runtime:18.0.0.4"
+}
+
+defaultTasks 'libertyCreate'

--- a/src/integTest/resources/sub-project-test/settings.gradle
+++ b/src/integTest/resources/sub-project-test/settings.gradle
@@ -1,0 +1,1 @@
+include ':webapp'

--- a/src/integTest/resources/sub-project-test/webapp/build.gradle
+++ b/src/integTest/resources/sub-project-test/webapp/build.gradle
@@ -1,0 +1,18 @@
+// We need to copy the root project's classpath because the Liberty Gradle tasks invoke
+// Liberty Ant tasks through a taskdef with classpath 'project.buildscript.configurations.classpath.asPath'.
+// Even though the Gradle classpath is inherited from the root project and the 'liberty' plugin and its
+// Gradle tasks can be loaded here, this breaks the wrapped invocation of the Liberty Ant tasks.
+buildscript {
+    repositories {
+        addAll rootProject.buildscript.repositories
+    }
+    dependencies {
+        classpath rootProject.buildscript.configurations.classpath.dependencies
+    }
+}
+
+liberty {
+    server {
+        name = project.name
+    }
+}

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallLibertyTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallLibertyTask.groovy
@@ -34,7 +34,7 @@ class InstallLibertyTask extends AbstractTask {
             group 'Liberty'
         })
         outputs.upToDateWhen {
-            getInstallDir(project).exists() && project.buildDir.exists()
+            getInstallDir(project).exists() && project.buildDir.exists() && new File(project.buildDir, 'liberty-plugin-config.xml').exists()
         }
     }
 
@@ -150,5 +150,13 @@ class InstallLibertyTask extends AbstractTask {
                 xmlDoc.assemblyArchive (project.configurations.libertyRuntime.resolvedConfiguration.resolvedArtifacts.getAt(0).file.toString())
             }
         }
+    }
+
+    private boolean runtimeUpToDate() {
+        boolean runtimeUpToDate = false
+
+        if (this.get)
+
+        return runtimeUpToDate
     }
 }

--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallLibertyTask.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/tasks/InstallLibertyTask.groovy
@@ -151,12 +151,4 @@ class InstallLibertyTask extends AbstractTask {
             }
         }
     }
-
-    private boolean runtimeUpToDate() {
-        boolean runtimeUpToDate = false
-
-        if (this.get)
-
-        return runtimeUpToDate
-    }
 }


### PR DESCRIPTION
Adding the liberty-plugin-config.xml file the up to date check in InstallLiberty.
Adding a new test to check that the liberty-plugin-config.xml file exists in the project's buildDir when the project is installing to a non buildDir installDir and that the subproject buildDir also has the xml file. This test is run before and after a clean.