### PR TITLE
Use ci.common 1.3.5-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile ('net.wasdev.wlp.ant:wlp-anttasks:1.6')
-    compile ('net.wasdev.wlp.common:ci.common:1.3.4')
+    compile ('net.wasdev.wlp.common:ci.common:1.3.5-SNAPSHOT')
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
     provided group: 'com.ibm.websphere.appserver.api', name: 'com.ibm.websphere.appserver.spi.kernel.embeddable', version: '1.0.0'
     testCompile 'junit:junit:4.11'


### PR DESCRIPTION
Update ci.common version to include WASdev/ci.common#24