### PR TITLE
Configuring Eclipse classpath to output to buildDir

### DIFF
--- a/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
+++ b/src/main/groovy/net/wasdev/wlp/gradle/plugins/Liberty.groovy
@@ -69,6 +69,8 @@ class Liberty implements Plugin<Project> {
             }
             //Checking serverEnv files for server properties
             Liberty.checkEtcServerEnvProperties(project)
+
+            setEclipseClasspath(project)
         }
     }
 
@@ -101,6 +103,25 @@ class Liberty implements Plugin<Project> {
                 def jstFacet = facets.find { it.type.name() == 'installed' && it.name == facetName && Double.parseDouble(it.version) < Double.parseDouble(version) }
                 if (jstFacet != null) {
                     jstFacet.version = version
+                }
+            }
+        }
+    }
+    
+    protected void setEclipseClasspath(Project project) {
+        if(project.plugins.hasPlugin('war')) {
+            //Configuring the Eclipse classpath to use the same directory as the war plugin for its output
+            //Using the default war/java plugin value
+            File warTaskOutput = new File("build/classes/java/main")
+            project.eclipse.classpath {
+                defaultOutputDir = warTaskOutput
+                file.whenMerged {
+                    entries.each {
+                        source ->
+                            if (source.kind == 'src' && source.hasProperty('output')) {
+                                source.output = warTaskOutput
+                            }
+                    }
                 }
             }
         }


### PR DESCRIPTION
The Eclipse `.classpath` file was configured so that Eclipse was compiling class files into `bin/main` but the loose application was looking for the files in `build/classes/java/main`.

Ended up configuring the `.classpath` file to use `build/classes/java/main` instead when the `.classpath` file is generated on project import to Eclipse. Existing `.classpath` files need to be deleted and the project needs to be imported again.

Fixes #314 