### PR TITLE
Signing only for Maven Central Releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 build
 *~
 *.DS_STORE
+gradle.properties

--- a/build.gradle
+++ b/build.gradle
@@ -174,11 +174,11 @@ pluginBundle {
 
 if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')) {
     
-if (!version.endsWith("SNAPSHOT")) {
-        signing {
-            sign configurations.archives
-        }
+  if (!version.endsWith("SNAPSHOT")) {
+      signing {
+        sign configurations.archives
     }
+  }
 
   uploadArchives {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,13 @@ pluginBundle {
 }
 
 if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')) {
+    
+if (!version.endsWith("SNAPSHOT")) {
+        signing {
+            sign configurations.archives
+        }
+    }
+
   uploadArchives {
     repositories {
       mavenDeployer {

--- a/build.gradle
+++ b/build.gradle
@@ -158,12 +158,6 @@ test {
     }
 }
 
-if (!version.endsWith("SNAPSHOT")) {
-    signing {
-        sign configurations.archives
-    }
-}
-
 pluginBundle {
   website = 'https://github.com/WASdev/ci.gradle'
   vcsUrl = 'https://github.com/WASdev/ci.gradle'


### PR DESCRIPTION
The signing block was breaking Gradle Plugin releases but is needed for Maven Central releases. Moved signing block to only run if it's a Maven Central release. 